### PR TITLE
Normalize images to [-1,1] and add reflection padding to residual blocks

### DIFF
--- a/load_data.py
+++ b/load_data.py
@@ -61,8 +61,7 @@ def create_image_array(image_list, image_path, nr_of_channels):
 
 
 def normalize_array(array):
-    max_value = max(array.flatten())
-    array = array / max_value
+    array = array / 127.5 - 1
     return array
 
 

--- a/model.py
+++ b/model.py
@@ -269,11 +269,13 @@ class CycleGAN():
     def Rk(self, x0):
         k = int(x0.shape[-1])
         # first layer
-        x = Conv2D(filters=k, kernel_size=3, strides=1, padding='same')(x0)
+        x = ReflectionPadding2D((1,1))(x0)
+        x = Conv2D(filters=k, kernel_size=3, strides=1, padding='valid')(x)
         x = self.normalization(axis=3, center=True, epsilon=1e-5)(x, training=True)
         x = Activation('relu')(x)
         # second layer
-        x = Conv2D(filters=k, kernel_size=3, strides=1, padding='same')(x)
+        x = ReflectionPadding2D((1, 1))(x)
+        x = Conv2D(filters=k, kernel_size=3, strides=1, padding='valid')(x)
         x = self.normalization(axis=3, center=True, epsilon=1e-5)(x, training=True)
         # merge
         x = add([x, x0])

--- a/model.py
+++ b/model.py
@@ -6,7 +6,7 @@ from keras.optimizers import Adam
 from keras.backend import mean
 from keras.models import Model, model_from_json
 from keras.utils import plot_model
-from keras.engine.topology import Container
+from keras.engine.topology import Network
 
 from collections import OrderedDict
 from scipy.misc import imsave, toimage  # has depricated
@@ -112,9 +112,9 @@ class CycleGAN():
                          loss=self.lse,
                          loss_weights=loss_weights_D)
 
-        # Use containers to avoid falsy keras error about weight descripancies
-        self.D_A_static = Container(inputs=image_A, outputs=guess_A, name='D_A_static_model')
-        self.D_B_static = Container(inputs=image_B, outputs=guess_B, name='D_B_static_model')
+        # Use Networks to avoid falsy keras error about weight descripancies
+        self.D_A_static = Network(inputs=image_A, outputs=guess_A, name='D_A_static_model')
+        self.D_B_static = Network(inputs=image_B, outputs=guess_B, name='D_B_static_model')
 
         # ======= Generator model ==========
         # Do note update discriminator weights during generator training
@@ -647,9 +647,6 @@ class CycleGAN():
             synthetic = synthetic[0]
             reconstructed = reconstructed[0]
 
-        synthetic = synthetic.clip(min=0)
-        reconstructed = reconstructed.clip(min=0)
-
         # Append and save
         if real_ is not None:
             if len(real_.shape) > 4:
@@ -661,7 +658,7 @@ class CycleGAN():
         if self.channels == 1:
             image = image[:, :, 0]
 
-        toimage(image, cmin=0, cmax=1).save(path_name)
+        toimage(image, cmin=-1, cmax=1).save(path_name)
 
     def saveImages(self, epoch, real_image_A, real_image_B, num_saved_images=1):
         directory = os.path.join('images', self.date_time)
@@ -843,8 +840,7 @@ class CycleGAN():
             def save_image(image, name, domain):
                 if self.channels == 1:
                     image = image[:, :, 0]
-                image = image.clip(min=0)
-                toimage(image, cmin=0, cmax=1).save(os.path.join(
+                toimage(image, cmin=-1, cmax=1).save(os.path.join(
                     'generate_images', 'synthetic_images', domain, name))
 
             # Test A images


### PR DESCRIPTION
Normalize input images to [-1,1] range by applying `im/127.5 - 1` formula during loading. This solves several issues with the histogram  of output images, as well as training convergence.

Add reflection padding to residual blocks. This seems to have a small effect in improving edge effects.

Both these changes align this implementation with the [original pyTorch implementation](https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix).

A final small change is replacing `Container` with `Network` for newer Keras versions.