### PR TITLE
The old Image saving method does not work

### DIFF
--- a/load_data.py
+++ b/load_data.py
@@ -61,7 +61,7 @@ def create_image_array(image_list, image_path, nr_of_channels):
 
 # If using 16 bit depth images, use the formula 'array = array / 32767.5 - 1' instead
 def normalize_array(array):
-    array = array / 127.5 - 1
+    array = array /255
     return array
 
 

--- a/model.py
+++ b/model.py
@@ -10,6 +10,7 @@ from keras.engine.topology import Network
 
 from collections import OrderedDict
 from scipy.misc import imsave, toimage  # has depricated
+from PIL import Image
 import numpy as np
 import random
 import datetime
@@ -659,8 +660,9 @@ class CycleGAN():
 
         if self.channels == 1:
             image = image[:, :, 0]
-
-        toimage(image, cmin=-1, cmax=1).save(path_name)
+        
+        image = image*(255)
+        Image.fromarray(image.astype('uint8')).save(path_name)
 
     def saveImages(self, epoch, real_image_A, real_image_B, num_saved_images=1):
         directory = os.path.join('images', self.date_time)


### PR DESCRIPTION
The old image saving method does not work because the scipy.msic does not contain "toImage" method now. I use Image module in PIL to replace it. because the image have been normalised in load_image method, so I times 255 for each image.