### PR TITLE
Updated model.py with indexing problem

### DIFF
--- a/model.py
+++ b/model.py
@@ -585,12 +585,12 @@ class CycleGAN():
                         # randomly pick from this domain
                         if len(A_train) <= len(B_train):
                             indexes_A = np.random.randint(len(A_train), size=batch_size)
-                            indexes_B = random_order_B[loop_index:
-                                                       loop_index + batch_size]
+                            indexes_B = random_order_B[min_nr_imgs - batch_size:
+                                                       min_nr_imgs]
                         else:
                             indexes_B = np.random.randint(len(B_train), size=batch_size)
-                            indexes_A = random_order_A[loop_index:
-                                                       loop_index + batch_size]
+                            indexes_A = random_order_A[min_nr_imgs - batch_size:
+                                                       min_nr_imgs]
                     else:
                         indexes_A = random_order_A[loop_index:
                                                    loop_index + batch_size]


### PR DESCRIPTION
A problem occurs when the loop_index + batch_size > minimum number of elements in dataset A/B (min(len(random_order_A), len(random_order_B))). The size of indexes_B is then smaller then batch_size which results in an error because indexes_A and indexes_B will not be of the same size anymore. 

This commit is one solution to fix this error.